### PR TITLE
Increase maximum WiFi password length to 63 characters

### DIFF
--- a/mopidy_websettings/index.html
+++ b/mopidy_websettings/index.html
@@ -54,7 +54,7 @@
             <label for="network__wifi_network">Wifi Network Name</label>
             <input type="text" name="network__wifi_network" value="{{ network__wifi_network }}" size="15" maxlength="40"/>
             <label for="network__wifi_password">Wifi Password</label>
-            <input type="password" name="network__wifi_password" value="{{ network__wifi_password }}" size="10" maxlength="40"/>
+            <input type="password" name="network__wifi_password" value="{{ network__wifi_password }}" size="10" maxlength="63"/>
 
             <label for="network__workgroup">Workgroup</label>
             <p>Here you can change the default workgroup of the Windows network. This will set the workgroup to the name you want</p>


### PR DESCRIPTION
This fixes #9 